### PR TITLE
20240511-05 - Fixed the setting of save file

### DIFF
--- a/com/sc/project/spadetools/ExtractFileNames.cs
+++ b/com/sc/project/spadetools/ExtractFileNames.cs
@@ -1,7 +1,4 @@
 
-using System.IO;
-using System.Text;
-
 namespace com.sc.project.spadetools {
     
     class ExtractFileNames {
@@ -81,7 +78,7 @@ namespace com.sc.project.spadetools {
                     else if (i == 0)
                     {
                         SetProperties("--root", arguments[0]);
-                        SetProperties("--save", RootDirectory + "\\extractedFileNames.txt");
+                        SetProperties("--save", RootDirectory);
                     }
                 }
             }
@@ -221,10 +218,11 @@ namespace com.sc.project.spadetools {
         #region SetSaveDirectory
         private void SetSaveFile(string parameter)
         {
-            // Validate that the save directory exists
-            if (!File.Exists(parameter))
+            // If directory is given, default the save file
+            if (Directory.Exists(parameter))
             {
-                File.Create(parameter);
+                SetSaveFile(parameter + "\\extractedFileNames.txt");
+                return;
             }
             saveFile = parameter;
         }
@@ -263,6 +261,12 @@ namespace com.sc.project.spadetools {
         {
             try
             {
+                // Validate that the save directory exists, create it not
+                if (!File.Exists(saveFile))
+                {
+                    File.Create(saveFile);
+                }
+
                 writtenDirectories.Sort();
                 File.WriteAllLines(saveFile, writtenDirectories);
             }


### PR DESCRIPTION
1. Allowed the creation of the save file to be compatible with the "1 argument as root directory" design
2. Moved the creation of the file when writing and not during pre-process arguments
- This ensures that it is compatible with 1 and no error is thrown when the save file is initially set to be equal to the root directory