### PR TITLE
20240513-01 - File write error is thrown

### DIFF
--- a/com/sc/project/spadetools/ExtractFileNames.cs
+++ b/com/sc/project/spadetools/ExtractFileNames.cs
@@ -264,13 +264,10 @@ namespace com.sc.project.spadetools {
                 {
                     SetSaveFile(RootDirectory);
                 }
-                // Validate that the save file exists, create it not
-                if (!File.Exists(saveFile))
-                {
-                    File.Create(saveFile);
-                }
-
+                
                 writtenDirectories.Sort();
+                // Close the file before writing
+                using (File.Create(saveFile)) { }  
                 File.WriteAllLines(saveFile, writtenDirectories);
             }
             catch (Exception)


### PR DESCRIPTION
File write error is thrown when file create is executed beforehand. File creation locks the file and not allowing file write.